### PR TITLE
changed link to the correct route

### DIFF
--- a/content/footer.ts
+++ b/content/footer.ts
@@ -37,7 +37,7 @@ export const footer = {
       name: 'About',
       links: [
         { label: 'About Us', href: '/about' },
-        { label: 'Contact us', href: '/contact-us' },
+        { label: 'Contact us', href: '/contact' },
         { label: 'Blog', href: '/blog' },
       ],
     },


### PR DESCRIPTION
Issue: Contact Us on the footer is routing to the wrong route. 

Fix: https://www.rconnect.tech/contact-us should be https://www.rconnect.tech/contact
